### PR TITLE
Fixed error in installing dependencies for api-server

### DIFF
--- a/api-server/pyproject.toml
+++ b/api-server/pyproject.toml
@@ -21,3 +21,6 @@ dependencies = [
 dev = [
     "ruff>=0.12.2",
 ]
+
+[tool.setuptools]
+packages = ["app", "logs"]


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file in the `api-server` directory. 
The change adds the `tool.setuptools` configuration to specify the packages `app` and `logs`.
- Fixes #56 

Dependency installation success screenshot:
<img width="1637" height="469" alt="Fix screenshot dependency installation sucess" src="https://github.com/user-attachments/assets/f600b2f3-e36a-4fd3-ac84-e4cef317ed43" />

