### PR TITLE
Implementation of a centralized caching manager for Redis

### DIFF
--- a/api-server/.gitignore
+++ b/api-server/.gitignore
@@ -28,10 +28,13 @@ ENV/
 .venv/
 
 # IDE
-.idea/
 .vscode/
 *.swp
 *.swo
+.idea/
+*.iws
+*.iml
+*.ipr
 
 
 # Local development

--- a/api-server/app/singletons/RedisOperation.py
+++ b/api-server/app/singletons/RedisOperation.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class RedisOperation(Enum):
+    """Enumeration of supported Redis operations."""
+    PING = "ping"
+    EXISTS = "exists"
+    GET = "get"
+    DELETE = "delete"
+    SET = "set"

--- a/api-server/app/singletons/redis_manager.py
+++ b/api-server/app/singletons/redis_manager.py
@@ -1,0 +1,169 @@
+import redis
+import os
+import time
+from typing import Any, Optional
+from redis.exceptions import RedisError, ConnectionError, TimeoutError
+
+from .RedisOperation import RedisOperation
+from .SingletonDecorator import singleton
+from .logs_manager import LogsManager
+
+
+@singleton
+class RedisManager:
+    """
+    Redis client manager singleton that provides a centralized interface for Redis operations.
+    Handles connection management, retries, and proper error logging.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize Redis connection with environment-based configuration.
+        Validates connection on startup.
+        """
+        self.logger = LogsManager().get_logger()
+        self.max_retries = int(os.getenv("REDIS_MAX_RETRIES", 3))
+        self.retry_delay = float(os.getenv("REDIS_RETRY_DELAY", 0.5))
+
+        self.client = redis.Redis(
+            host=os.getenv("REDIS_HOST", "redis-master"),
+            port=int(os.getenv("REDIS_PORT", 6379)),
+            password=os.getenv("REDIS_PASSWORD", ""),
+            db=int(os.getenv("REDIS_DB", 0)),
+            decode_responses=True,
+            socket_connect_timeout=5,
+            socket_timeout=5,
+            retry_on_timeout=True
+        )
+
+        self._validate_connection()
+
+    def _validate_connection(self) -> bool:
+        """
+        Test the Redis connection with retries.
+
+        Returns:
+            bool: True if connection successful, False otherwise
+        """
+        for attempt in range(self.max_retries):
+            try:
+                self.client.ping()
+                return True
+            except ConnectionError as e:
+                self.logger.error("Redis connection failed",
+                                  attempt=attempt + 1,
+                                  max_attempts=self.max_retries,
+                                  error=str(e))
+                if attempt < self.max_retries - 1:
+                    time.sleep(self.retry_delay)
+
+        self.logger.error("All Redis connection attempts failed")
+        return False
+
+    def get_client(self) -> redis.Redis:
+        """
+        Get the underlying Redis client.
+
+        Returns:
+            redis.Redis: The Redis client instance
+        """
+        return self.client
+
+    def _execute_with_retry(self, operation: RedisOperation, *args, **kwargs) -> Any:
+        """
+        Execute Redis operation with retry logic.
+
+        Args:
+            operation: Name of the Redis operation to perform
+            *args: Arguments to pass to the Redis operation
+            **kwargs: Keyword arguments to pass to the Redis operation
+
+        Returns:
+            Any: Result of the Redis operation
+        """
+        for attempt in range(self.max_retries):
+            try:
+                method = getattr(self.client, operation.value)
+                return method(*args, **kwargs)
+            except (ConnectionError, TimeoutError) as e:
+                self.logger.warning(
+                    "Redis operation failed, retrying",
+                    operation=operation,
+                    attempt=attempt + 1,
+                    max_attempts=self.max_retries,
+                    error=str(e)
+                )
+                if attempt < self.max_retries - 1:
+                    time.sleep(self.retry_delay)
+
+        self.logger.error("Redis operation failed after retries", operation=operation)
+        raise RedisError(f"Operation {operation} failed after {self.max_retries} attempts")
+
+    def set_with_ttl(self, key: str, value: str, ttl_seconds: int) -> bool:
+        """
+        Set a key with TTL in seconds.
+
+        Args:
+            key: Redis key name
+            value: Value to store
+            ttl_seconds: Time-to-live in seconds
+
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        try:
+            return self._execute_with_retry(RedisOperation.SET, key, value, ex=ttl_seconds)
+        except RedisError as e:
+            self.logger.error("Failed to set key with TTL",
+                              key=key,
+                              ttl_seconds=ttl_seconds,
+                              error=str(e))
+            return False
+
+    def exists(self, key: str) -> bool:
+        """
+        Check if a key exists in Redis.
+
+        Args:
+            key: Redis key name
+
+        Returns:
+            bool: True if key exists, False otherwise
+        """
+        try:
+            return self._execute_with_retry(RedisOperation.EXISTS, key) > 0
+        except RedisError as e:
+            self.logger.error("Failed to check key existence", key=key, error=str(e))
+            return False
+
+    def get(self, key: str) -> Optional[str]:
+        """
+        Get a value by key.
+
+        Args:
+            key: Redis key name
+
+        Returns:
+            Optional[str]: Value if found, None otherwise
+        """
+        try:
+            return self._execute_with_retry(RedisOperation.GET, key)
+        except RedisError as e:
+            self.logger.error("Failed to get key", key=key, error=str(e))
+            return None
+
+    def delete(self, key: str) -> bool:
+        """
+        Delete a key from Redis.
+
+        Args:
+            key: Redis key name
+
+        Returns:
+            bool: True if deleted, False otherwise
+        """
+        try:
+            return bool(self._execute_with_retry(RedisOperation.DELETE, key))
+        except RedisError as e:
+            self.logger.error("Failed to delete key", key=key, error=str(e))
+            return False

--- a/api-server/pyproject.toml
+++ b/api-server/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-dotenv>=1.1.1",
     "structlog>=25.4.0",
     "uvicorn>=0.35.0",
+    "redis>= 6.0.0"
 ]
 
 [dependency-groups]

--- a/api-server/pyproject.toml
+++ b/api-server/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "python-dotenv>=1.1.1",
     "structlog>=25.4.0",
     "uvicorn>=0.35.0",
-    "redis>= 6.0.0"
+    "redis[hiredis]>=6.0.0"
 ]
 
 [dependency-groups]

--- a/api-server/pytest.ini
+++ b/api-server/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+markers =
+    unit: marks a test as a unit test
+    integration: marks a test as an integration test

--- a/api-server/tests/integration/auth/singletons/test_redis_manager_integration.py
+++ b/api-server/tests/integration/auth/singletons/test_redis_manager_integration.py
@@ -1,0 +1,181 @@
+"""
+Integration tests for the RedisManager singleton class.
+
+These tests are designed to be run against a live Redis instance to verify
+real-world behavior. They are structured in a modular and extensible way
+using a test class and pytest fixtures.
+
+Prerequisites:
+- A running Redis instance (e.g., via Docker: `docker run -d -p 6379:6379 redis`)
+- `pytest` and `redis` packages installed.
+"""
+import pytest
+import os
+import uuid
+import time
+import sys
+from collections.abc import Generator
+
+# Get the absolute path to the api-server directory
+api_server_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..'))
+sys.path.insert(0, api_server_dir)
+
+from app.singletons.redis_manager import RedisManager
+from app.singletons.RedisOperation import RedisOperation
+from app.singletons.SingletonDecorator import singleton
+
+# Mark all tests in this file as integration tests, allowing them to be run
+# separately from unit tests (e.g., `pytest -m integration`).
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture #(scope="session")
+def redis_manager_fixture() -> Generator[RedisManager, None, None]:
+    """
+    A session-scoped fixture that provides a single, clean RedisManager instance
+    for the entire test session. It handles environment setup, singleton resetting,
+    and database cleanup.
+    """
+    # --- Environment Setup ---
+    # Store original environment variables to restore them after the test session.
+    original_env = {
+        'REDIS_HOST': os.environ.get('REDIS_HOST'),
+        'REDIS_PORT': os.environ.get('REDIS_PORT'),
+        'REDIS_PASSWORD': os.environ.get('REDIS_PASSWORD'),
+        'REDIS_DB': os.environ.get('REDIS_DB')
+    }
+
+    # Configure the environment for a local test Redis instance.
+    os.environ['REDIS_HOST'] = 'localhost'
+    os.environ['REDIS_PORT'] = '6379'
+    os.environ['REDIS_PASSWORD'] = ''  # Assumes no password for local test instance
+    os.environ['REDIS_DB'] = '1'  # Use a dedicated DB to isolate tests.
+
+    # --- Singleton and DB Reset ---
+    # Access the internal dictionary of the singleton decorator and clear it.
+    # This ensures we get a fresh instance.
+    if hasattr(singleton, '__closure__') and singleton.__closure__:
+        for cell in singleton.__closure__:
+            if isinstance(cell.cell_contents, dict):
+                cell.cell_contents.clear()
+                break
+
+    # --- Fixture Provision ---
+    # Initialize the manager and ensure the connection is live.
+    try:
+        manager = RedisManager()
+        client = manager.get_client()
+        client.ping()
+    except Exception as e:
+        pytest.fail(
+            "Could not initialize RedisManager. Is Redis running and accessible? "
+            f"Error: {e}"
+        )
+
+    # Yield the manager instance to the tests.
+    yield manager
+
+    # --- Teardown ---
+    # Flush the test database after all tests in the session are complete.
+    client.flushdb()
+
+    # Restore the original environment variables.
+    for key, value in original_env.items():
+        if value is not None:
+            os.environ[key] = value
+        elif key in os.environ:
+            del os.environ[key]
+
+
+class TestRedisManagerIntegration:
+    """
+    A test class to group all integration tests for the RedisManager.
+    This modular structure makes the tests more organized and readable.
+    """
+
+    @staticmethod
+    def _generate_key(prefix: str) -> str:
+        """Helper method to create unique keys for each test."""
+        return f"test:{prefix}:{uuid.uuid4()}"
+
+    def test_singleton_pattern_is_maintained(self, redis_manager_fixture: RedisManager):
+        """
+        Verify that multiple calls to RedisManager() return the exact same
+        object instance, confirming the singleton pattern works as expected.
+        """
+        # The fixture already created the first instance.
+        manager1 = redis_manager_fixture
+        # Calling it again should return the cached instance.
+        manager2 = RedisManager()
+
+        assert manager1 is manager2, "RedisManager did not return the same instance."
+        assert manager1.get_client() is manager2.get_client(), "Clients from different calls are not the same instance."
+
+    def test_set_and_get_value(self, redis_manager_fixture: RedisManager):
+        """
+        Test the fundamental set and get operations to ensure data integrity.
+        """
+        test_key = self._generate_key("set_get")
+        test_value = f"value-{uuid.uuid4()}"
+
+        # Set a value with a standard TTL.
+        set_success = redis_manager_fixture.set_with_ttl(test_key, test_value, 60)
+        assert set_success, "set_with_ttl should return True on success."
+
+        # Retrieve the value and verify it's correct.
+        retrieved_value = redis_manager_fixture.get(test_key)
+        assert retrieved_value == test_value, "get should retrieve the exact value that was set."
+
+    def test_exists_operation(self, redis_manager_fixture: RedisManager):
+        """
+        Verify the exists() method correctly identifies existing and
+        non-existing keys.
+        """
+        existing_key = self._generate_key("exists_positive")
+        non_existing_key = self._generate_key("exists_negative")
+
+        # Set a key to ensure it exists.
+        redis_manager_fixture.set_with_ttl(existing_key, "some_value", 10)
+
+        # Assert that exists() returns True for the key we just set.
+        assert redis_manager_fixture.exists(existing_key), "exists() should return True for a key that has been set."
+
+        # Assert that exists() returns False for a key that has not been set.
+        assert not redis_manager_fixture.exists(
+            non_existing_key), "exists() should return False for a non-existent key."
+
+    def test_delete_operation(self, redis_manager_fixture: RedisManager):
+        """
+        Verify that the delete() operation successfully removes a key and
+        handles non-existent keys gracefully.
+        """
+        test_key = self._generate_key("delete")
+
+        # Set a key to be deleted.
+        redis_manager_fixture.set_with_ttl(test_key, "to_be_deleted", 10)
+        assert redis_manager_fixture.exists(test_key), "Key should exist before deletion."
+
+        # Delete the key and verify the operation's success.
+        assert redis_manager_fixture.delete(test_key), "delete() should return True for an existing key."
+        assert not redis_manager_fixture.exists(test_key), "Key should not exist after being deleted."
+
+        # Attempting to delete a non-existent key should return False.
+        assert not redis_manager_fixture.delete(test_key), "delete() should return False for a non-existent key."
+
+    def test_ttl_expiration(self, redis_manager_fixture: RedisManager):
+        """
+        Verify that a key with a TTL correctly expires and is removed from
+        the database after the specified time.
+        """
+        test_key = self._generate_key("ttl")
+        ttl_seconds = 1  # Use a short TTL for a quick test.
+
+        # Set the key with a 1-second TTL.
+        redis_manager_fixture.set_with_ttl(test_key, "expiring_value", ttl_seconds)
+        assert redis_manager_fixture.exists(test_key), "Key should exist immediately after being set."
+
+        # Wait for a duration longer than the TTL to allow for expiration.
+        time.sleep(ttl_seconds + 0.5)
+
+        # Verify the key has expired and no longer exists.
+        assert not redis_manager_fixture.exists(test_key), "Key should no longer exist after its TTL has passed."

--- a/api-server/tests/integration/auth/singletons/test_redis_manager_integration.py
+++ b/api-server/tests/integration/auth/singletons/test_redis_manager_integration.py
@@ -9,20 +9,22 @@ Prerequisites:
 - A running Redis instance (e.g., via Docker: `docker run -d -p 6379:6379 redis`)
 - `pytest` and `redis` packages installed.
 """
-import pytest
-import os
-import uuid
-import time
+
 import sys
-from collections.abc import Generator
+import os
 
 # Get the absolute path to the api-server directory
-api_server_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..'))
-sys.path.insert(0, api_server_dir)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..')))
 
 from app.singletons.redis_manager import RedisManager
-from app.singletons.RedisOperation import RedisOperation
 from app.singletons.SingletonDecorator import singleton
+
+import pytest
+import uuid
+import time
+from collections.abc import Generator
+
+
 
 # Mark all tests in this file as integration tests, allowing them to be run
 # separately from unit tests (e.g., `pytest -m integration`).

--- a/api-server/tests/unit/auth/singletons/test_redis_manager.py
+++ b/api-server/tests/unit/auth/singletons/test_redis_manager.py
@@ -1,0 +1,238 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import os
+import sys
+
+# Ensure the application's root directory is in the Python path to allow for absolute imports.
+# This makes the test suite independent of the directory it's run from.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..')))
+
+from app.singletons.RedisOperation import RedisOperation
+from redis.exceptions import RedisError, ConnectionError, TimeoutError
+from app.singletons.redis_manager import RedisManager
+
+
+class TestRedisManager(unittest.TestCase):
+    """
+    A comprehensive, from-scratch test suite for the RedisManager singleton.
+
+    This suite ensures that every component of the RedisManager is tested in isolation,
+    with a robust setup and teardown process to handle the singleton pattern correctly.
+    """
+
+    def setUp(self):
+        """
+        Set up a clean, controlled environment before each test.
+
+        This method patches all external dependencies to ensure tests are fast and reliable.
+        """
+        # Reset the singleton's instance cache before each test. This is the most
+        # critical step for ensuring test isolation.
+        if hasattr(RedisManager, '__closure__') and RedisManager.__closure__:
+            for cell in RedisManager.__closure__:
+                if isinstance(cell.cell_contents, dict):
+                    cell.cell_contents.clear()
+                    break
+
+        # --- Mock Dependencies ---
+        # We use patchers here to manage starting and stopping the patches cleanly.
+        self.logs_patcher = patch('app.singletons.redis_manager.LogsManager')
+        self.redis_patcher = patch('app.singletons.redis_manager.redis.Redis')
+        self.sleep_patcher = patch('time.sleep')
+
+        self.mock_logs_manager_class = self.logs_patcher.start()
+        self.mock_redis_class = self.redis_patcher.start()
+        self.mock_sleep = self.sleep_patcher.start()
+
+        # Configure the mocks that were just created.
+        self.mock_redis_client = MagicMock()
+
+        # By default, we make the ping successful so RedisManager initializes without error.
+        self.mock_redis_client.ping.return_value = True
+        self.mock_redis_class.return_value = self.mock_redis_client
+
+        self.mock_logger = MagicMock()
+        self.mock_logs_manager_class.return_value.get_logger.return_value = self.mock_logger
+
+    def tearDown(self):
+        """
+        Clean up the environment after each test by stopping all patchers.
+        """
+        patch.stopall()
+
+    def test_initialization_with_custom_env_vars(self):
+        """
+        Verify that RedisManager correctly initializes using environment variables.
+        """
+        env_vars = {
+            'REDIS_HOST': 'env-host',
+            'REDIS_PORT': '9999',
+            'REDIS_PASSWORD': 'env-password',
+            'REDIS_DB': '10',
+            'REDIS_MAX_RETRIES': '5',
+            'REDIS_RETRY_DELAY': '2.5'
+        }
+        with patch.dict(os.environ, env_vars):
+            # We reset the mock just before creating the instance to have a clean slate for our assertion.
+            self.mock_redis_client.ping.reset_mock()
+            manager = RedisManager()
+
+            # Verify that the redis client was instantiated with the correct config.
+            self.mock_redis_class.assert_called_once_with(
+                host='env-host',
+                port=9999,
+                password='env-password',
+                db=10,
+                decode_responses=True,
+                socket_connect_timeout=5,
+                socket_timeout=5,
+                retry_on_timeout=True
+            )
+
+            # Verify that the manager's internal config is set correctly.
+            self.assertEqual(manager.max_retries, 5)
+            self.assertEqual(manager.retry_delay, 2.5)
+
+            # Verify that the connection was validated via a ping call during initialization.
+            self.mock_redis_client.ping.assert_called_once()
+
+    def test_get_client_returns_instance(self):
+        """
+        Verify that get_client() returns the underlying Redis client instance.
+        """
+        manager = RedisManager()
+        client = manager.get_client()
+        self.assertEqual(client, self.mock_redis_client)
+
+    def test_validate_connection_success_on_first_try(self):
+        """
+        Verify _validate_connection returns True on immediate success.
+        """
+        manager = RedisManager()
+        # Reset mock from the call made in __init__ to test the method in isolation.
+        self.mock_redis_client.ping.reset_mock()
+
+        # Manually call the real method and check its behavior.
+        result = manager._validate_connection()
+
+        self.assertTrue(result)
+        self.mock_redis_client.ping.assert_called_once()
+        self.mock_sleep.assert_not_called()
+
+    def test_validate_connection_succeeds_after_retries(self):
+        """
+        Verify _validate_connection retries on failure and eventually succeeds.
+        """
+        manager = RedisManager()
+        self.mock_redis_client.ping.reset_mock()  # Reset from __init__ call.
+
+        # Simulate two failures, then a success.
+        self.mock_redis_client.ping.side_effect = [ConnectionError, ConnectionError, True]
+
+        result = manager._validate_connection()
+
+        self.assertTrue(result)
+        self.assertEqual(self.mock_redis_client.ping.call_count, 3)
+        self.mock_sleep.assert_has_calls([call(manager.retry_delay), call(manager.retry_delay)])
+
+    def test_validate_connection_fails_after_all_retries(self):
+        """
+        Verify _validate_connection returns False if all attempts fail.
+        """
+        manager = RedisManager()
+        self.mock_redis_client.ping.reset_mock()  # Reset from __init__ call.
+
+        manager.max_retries = 3  # Explicitly set for clarity
+        self.mock_redis_client.ping.side_effect = ConnectionError("Connection failed")
+
+        result = manager._validate_connection()
+
+        self.assertFalse(result)
+        self.assertEqual(self.mock_redis_client.ping.call_count, 3)
+        self.mock_logger.error.assert_called_with("All Redis connection attempts failed")
+
+    def test_execute_with_retry_raises_error_after_failures(self):
+        """
+        Verify _execute_with_retry raises RedisError after all retries fail.
+        """
+        manager = RedisManager()
+        manager.max_retries = 2
+        self.mock_redis_client.get.side_effect = TimeoutError("Timed out")
+
+        with self.assertRaises(RedisError):
+            manager._execute_with_retry(RedisOperation.GET, "some-key")
+
+        self.assertEqual(self.mock_redis_client.get.call_count, 2)
+        self.mock_logger.error.assert_called_with(
+            "Redis operation failed after retries", operation=RedisOperation.GET
+        )
+
+    # --- Tests for Public Methods (these rely on the mocked _execute_with_retry) ---
+
+    def test_set_with_ttl_success(self):
+        """Test set_with_ttl succeeds by calling _execute_with_retry."""
+        manager = RedisManager()
+        with patch.object(manager, '_execute_with_retry') as mock_execute:
+            manager.set_with_ttl("my-key", "my-value", 3600)
+            mock_execute.assert_called_once_with(RedisOperation.SET, "my-key", "my-value", ex=3600)
+
+    def test_set_with_ttl_failure_logs_error(self):
+        """Test set_with_ttl returns False and logs an error on failure."""
+        manager = RedisManager()
+        with patch.object(manager, '_execute_with_retry', side_effect=RedisError("Set failed")):
+            result = manager.set_with_ttl("my-key", "my-value", 3600)
+
+            self.assertFalse(result)
+            self.mock_logger.error.assert_called_once_with(
+                "Failed to set key with TTL",
+                key="my-key",
+                ttl_seconds=3600,
+                error="Set failed"
+            )
+
+    def test_exists_returns_true_when_key_present(self):
+        """Test exists() returns True when _execute_with_retry returns > 0."""
+        manager = RedisManager()
+        with patch.object(manager, '_execute_with_retry', return_value=1) as mock_execute:
+            self.assertTrue(manager.exists("my-key"))
+            mock_execute.assert_called_once_with(RedisOperation.EXISTS, "my-key")
+
+    def test_get_returns_value_on_success(self):
+        """Test get() returns the correct value from _execute_with_retry."""
+        manager = RedisManager()
+        with patch.object(manager, '_execute_with_retry', return_value="the-stored-value") as mock_execute:
+            result = manager.get("my-key")
+            self.assertEqual(result, "the-stored-value")
+            mock_execute.assert_called_once_with(RedisOperation.GET, "my-key")
+
+    def test_get_returns_none_on_failure(self):
+        """Test get() returns None and logs an error on failure."""
+        manager = RedisManager()
+        with patch.object(manager, '_execute_with_retry', side_effect=RedisError("Get failed")):
+            result = manager.get("my-key")
+            self.assertIsNone(result)
+            self.mock_logger.error.assert_called_once_with(
+                "Failed to get key", key="my-key", error="Get failed"
+            )
+
+    def test_delete_returns_true_on_success(self):
+        """Test delete() returns True when a key is successfully deleted."""
+        manager = RedisManager()
+        with patch.object(manager, '_execute_with_retry', return_value=1) as mock_execute:
+            result = manager.delete("my-key")
+            self.assertTrue(result)
+            mock_execute.assert_called_once_with(RedisOperation.DELETE, "my-key")
+
+    def test_delete_returns_false_on_failure(self):
+        """Test delete() returns False and logs an error on failure."""
+        manager = RedisManager()
+        with patch.object(manager, '_execute_with_retry', side_effect=RedisError("Delete failed")):
+            result = manager.delete("my-key")
+            self.assertFalse(result)
+            self.mock_logger.error.assert_called_once_with(
+                "Failed to delete key", key="my-key", error="Delete failed"
+            )
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/api-server/uv.lock
+++ b/api-server/uv.lock
@@ -38,7 +38,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
-    { name = "redis" },
+    { name = "redis", extra = ["hiredis"] },
     { name = "structlog" },
     { name = "uvicorn" },
 ]
@@ -58,7 +58,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.24.0" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
-    { name = "redis", specifier = ">=6.0.0" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=6.0.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
@@ -217,6 +217,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hiredis"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/08/24b72f425b75e1de7442fb1740f69ca66d5820b9f9c0e2511ff9aadab3b7/hiredis-3.2.1.tar.gz", hash = "sha256:5a5f64479bf04dd829fe7029fad0ea043eac4023abc6e946668cbbec3493a78d", size = 89096, upload-time = "2025-05-23T11:41:57.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/a1/6da1578a22df1926497f7a3f6a3d2408fe1d1559f762c1640af5762a8eb6/hiredis-3.2.1-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:3742d8b17e73c198cabeab11da35f2e2a81999d406f52c6275234592256bf8e8", size = 82627, upload-time = "2025-05-23T11:40:15.362Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/b1/1056558ca8dc330be5bb25162fe5f268fee71571c9a535153df9f871a073/hiredis-3.2.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:9c2f3176fb617a79f6cccf22cb7d2715e590acb534af6a82b41f8196ad59375d", size = 45404, upload-time = "2025-05-23T11:40:16.72Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4f/13d1fa1a6b02a99e9fed8f546396f2d598c3613c98e6c399a3284fa65361/hiredis-3.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a8bd46189c7fa46174e02670dc44dfecb60f5bd4b67ed88cb050d8f1fd842f09", size = 43299, upload-time = "2025-05-23T11:40:17.697Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/25/ddfac123ba5a32eb1f0b40ba1b2ec98a599287f7439def8856c3c7e5dd0d/hiredis-3.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f86ee4488c8575b58139cdfdddeae17f91e9a893ffee20260822add443592e2f", size = 172194, upload-time = "2025-05-23T11:40:19.143Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/1e/443a3703ce570b631ca43494094fbaeb051578a0ebe4bfcefde351e1ba25/hiredis-3.2.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3717832f4a557b2fe7060b9d4a7900e5de287a15595e398c3f04df69019ca69d", size = 168429, upload-time = "2025-05-23T11:40:20.329Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/0d8c6c706ed79b2298c001b5458c055615e3166533dcee3900e821a18a3e/hiredis-3.2.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5cb12c21fb9e2403d28c4e6a38120164973342d34d08120f2d7009b66785644", size = 182967, upload-time = "2025-05-23T11:40:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/da8dd231fbce858b5a20ab7d7bf558912cd125f08bac4c778865ef5fe2c2/hiredis-3.2.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:080fda1510bbd389af91f919c11a4f2aa4d92f0684afa4709236faa084a42cac", size = 172495, upload-time = "2025-05-23T11:40:23.105Z" },
+    { url = "https://files.pythonhosted.org/packages/65/25/83a31420535e2778662caa95533d5c997011fa6a88331f0cdb22afea9ec3/hiredis-3.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1252e10a1f3273d1c6bf2021e461652c2e11b05b83e0915d6eb540ec7539afe2", size = 173142, upload-time = "2025-05-23T11:40:24.24Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d7/cb907348889eb75e2aa2e6b63e065b611459e0f21fe1e371a968e13f0d55/hiredis-3.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d9e320e99ab7d2a30dc91ff6f745ba38d39b23f43d345cdee9881329d7b511d6", size = 166433, upload-time = "2025-05-23T11:40:25.287Z" },
+    { url = "https://files.pythonhosted.org/packages/01/5d/7cbc69d82af7b29a95723d50f5261555ba3d024bfbdc414bdc3d23c0defb/hiredis-3.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:641668f385f16550fdd6fdc109b0af6988b94ba2acc06770a5e06a16e88f320c", size = 164883, upload-time = "2025-05-23T11:40:26.454Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/00/f995b1296b1d7e0247651347aa230f3225a9800e504fdf553cf7cd001cf7/hiredis-3.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1e1f44208c39d6c345ff451f82f21e9eeda6fe9af4ac65972cc3eeb58d41f7cb", size = 177262, upload-time = "2025-05-23T11:40:27.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/723a67d729e94764ce9e0d73fa5f72a0f87d3ce3c98c9a0b27cbf001cc79/hiredis-3.2.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:f882a0d6415fffe1ffcb09e6281d0ba8b1ece470e866612bbb24425bf76cf397", size = 169619, upload-time = "2025-05-23T11:40:29.671Z" },
+    { url = "https://files.pythonhosted.org/packages/45/58/f69028df00fb1b223e221403f3be2059ae86031e7885f955d26236bdfc17/hiredis-3.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b4e78719a0730ebffe335528531d154bc8867a246418f74ecd88adbc4d938c49", size = 167303, upload-time = "2025-05-23T11:40:30.902Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/7d/567411e65cce76cf265a9a4f837fd2ebc564bef6368dd42ac03f7a517c0a/hiredis-3.2.1-cp312-cp312-win32.whl", hash = "sha256:33c4604d9f79a13b84da79950a8255433fca7edaf292bbd3364fd620864ed7b2", size = 20551, upload-time = "2025-05-23T11:40:32.69Z" },
+    { url = "https://files.pythonhosted.org/packages/90/74/b4c291eb4a4a874b3690ff9fc311a65d5292072556421b11b1d786e3e1d0/hiredis-3.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7b9749375bf9d171aab8813694f379f2cff0330d7424000f5e92890ad4932dc9", size = 22128, upload-time = "2025-05-23T11:40:33.686Z" },
+    { url = "https://files.pythonhosted.org/packages/47/91/c07e737288e891c974277b9fa090f0a43c72ab6ccb5182117588f1c01269/hiredis-3.2.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:7cabf7f1f06be221e1cbed1f34f00891a7bdfad05b23e4d315007dd42148f3d4", size = 82636, upload-time = "2025-05-23T11:40:35.035Z" },
+    { url = "https://files.pythonhosted.org/packages/92/20/02cb1820360eda419bc17eb835eca976079e2b3e48aecc5de0666b79a54c/hiredis-3.2.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:db85cb86f8114c314d0ec6d8de25b060a2590b4713135240d568da4f7dea97ac", size = 45404, upload-time = "2025-05-23T11:40:36.113Z" },
+    { url = "https://files.pythonhosted.org/packages/87/51/d30a4aadab8670ed9d40df4982bc06c891ee1da5cdd88d16a74e1ecbd520/hiredis-3.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c9a592a49b7b8497e4e62c3ff40700d0c7f1a42d145b71e3e23c385df573c964", size = 43301, upload-time = "2025-05-23T11:40:37.557Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7b/2c613e1bb5c2e2bac36e8befeefdd58b42816befb17e26ab600adfe337fb/hiredis-3.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0079ef1e03930b364556b78548e67236ab3def4e07e674f6adfc52944aa972dd", size = 172486, upload-time = "2025-05-23T11:40:38.659Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/df/8f2c4fcc28d6f5178b25ee1ba2157cc473f9908c16ce4b8e0bdd79e38b05/hiredis-3.2.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d6a290ed45d9c14f4c50b6bda07afb60f270c69b5cb626fd23a4c2fde9e3da1", size = 168532, upload-time = "2025-05-23T11:40:39.843Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ae/d0864ffaa0461e29a6940a11c858daf78c99476c06ed531b41ad2255ec25/hiredis-3.2.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79dd5fe8c0892769f82949adeb021342ca46871af26e26945eb55d044fcdf0d0", size = 183216, upload-time = "2025-05-23T11:40:41.005Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/558e831b77692d73f5bcf8b493ab3eace9f11b0aa08839cdbb87995152c7/hiredis-3.2.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:998a82281a159f4aebbfd4fb45cfe24eb111145206df2951d95bc75327983b58", size = 172689, upload-time = "2025-05-23T11:40:42.153Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b9/4fccda21f930f08c5072ad51e825d85d457748138443d7b510afe77b8264/hiredis-3.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41fc3cd52368ffe7c8e489fb83af5e99f86008ed7f9d9ba33b35fec54f215c0a", size = 173319, upload-time = "2025-05-23T11:40:43.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/596d613588b0a3c58dfcf9a17edc6a886c4de6a3096e27c7142a94e2304d/hiredis-3.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8d10df3575ce09b0fa54b8582f57039dcbdafde5de698923a33f601d2e2a246c", size = 166695, upload-time = "2025-05-23T11:40:44.453Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/5b/6a1c266e9f6627a8be1fa0d8622e35e35c76ae40cce6d1c78a7e6021184a/hiredis-3.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1ab010d04be33735ad8e643a40af0d68a21d70a57b1d0bff9b6a66b28cca9dbf", size = 165181, upload-time = "2025-05-23T11:40:45.697Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/70/a9b91fa70d21763d9dfd1c27ddd378f130749a0ae4a0645552f754b3d1fc/hiredis-3.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ec3b5f9ea34f70aaba3e061cbe1fa3556fea401d41f5af321b13e326792f3017", size = 177589, upload-time = "2025-05-23T11:40:46.903Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/31bbb015156dc4441f6e19daa9598266a61445bf3f6e14c44292764638f6/hiredis-3.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:158dfb505fff6bffd17f823a56effc0c2a7a8bc4fb659d79a52782f22eefc697", size = 169883, upload-time = "2025-05-23T11:40:48.111Z" },
+    { url = "https://files.pythonhosted.org/packages/89/44/cddc23379e0ce20ad7514b2adb2aa2c9b470ffb1ca0a2d8c020748962a22/hiredis-3.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d632cd0ddd7895081be76748e6fb9286f81d2a51c371b516541c6324f2fdac9", size = 167585, upload-time = "2025-05-23T11:40:49.208Z" },
+    { url = "https://files.pythonhosted.org/packages/48/92/8fc9b981ed01fc2bbac463a203455cd493482b749801bb555ebac72923f1/hiredis-3.2.1-cp313-cp313-win32.whl", hash = "sha256:e9726d03e7df068bf755f6d1ecc61f7fc35c6b20363c7b1b96f39a14083df940", size = 20554, upload-time = "2025-05-23T11:40:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/6e/e76341d68aa717a705a2ee3be6da9f4122a0d1e3f3ad93a7104ed7a81bea/hiredis-3.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:b5b1653ad7263a001f2e907e81a957d6087625f9700fa404f1a2268c0a4f9059", size = 22136, upload-time = "2025-05-23T11:40:51.497Z" },
 ]
 
 [[package]]
@@ -399,6 +437,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/0551e01ba52b944f97480721656578c8a7c46b51b99d66814f85fe3a4f3e/redis-6.2.0.tar.gz", hash = "sha256:e821f129b75dde6cb99dd35e5c76e8c49512a5a0d8dfdc560b2fbd44b85ca977", size = 4639129, upload-time = "2025-05-28T05:01:18.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/67/e60968d3b0e077495a8fee89cf3f2373db98e528288a48f1ee44967f6e8c/redis-6.2.0-py3-none-any.whl", hash = "sha256:c8ddf316ee0aab65f04a11229e94a64b2618451dab7a67cb2f77eb799d872d5e", size = 278659, upload-time = "2025-05-28T05:01:16.955Z" },
+]
+
+[package.optional-dependencies]
+hiredis = [
+    { name = "hiredis" },
 ]
 
 [[package]]

--- a/api-server/uv.lock
+++ b/api-server/uv.lock
@@ -38,6 +38,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
+    { name = "redis" },
     { name = "structlog" },
     { name = "uvicorn" },
 ]
@@ -57,6 +58,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.24.0" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "redis", specifier = ">=6.0.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
@@ -388,6 +390,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+]
+
+[[package]]
+name = "redis"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/0551e01ba52b944f97480721656578c8a7c46b51b99d66814f85fe3a4f3e/redis-6.2.0.tar.gz", hash = "sha256:e821f129b75dde6cb99dd35e5c76e8c49512a5a0d8dfdc560b2fbd44b85ca977", size = 4639129, upload-time = "2025-05-28T05:01:18.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/67/e60968d3b0e077495a8fee89cf3f2373db98e528288a48f1ee44967f6e8c/redis-6.2.0-py3-none-any.whl", hash = "sha256:c8ddf316ee0aab65f04a11229e94a64b2618451dab7a67cb2f77eb799d872d5e", size = 278659, upload-time = "2025-05-28T05:01:16.955Z" },
 ]
 
 [[package]]

--- a/k8s/redis-values.yaml
+++ b/k8s/redis-values.yaml
@@ -13,6 +13,10 @@ master:
     limits:
       cpu: 1000m
       memory: 4096Mi
+  configuration: |
+    maxmemory 3gb
+    maxmemory-policy volatile-ttl
+    maxmemory-samples 10
 
 metrics:
   enabled: true


### PR DESCRIPTION
Fixes #64 

This pull request introduces a Redis client manager (`RedisManager`) as a singleton with robust connection handling, retry logic, and support for common Redis operations. It also includes both unit and integration tests for the new functionality, updates to dependencies, and configuration changes for Redis in Kubernetes. Below is a summary of the most important changes:

### Redis Manager Implementation
* Added `RedisManager` class to manage Redis connections and operations, including methods for `set_with_ttl`, `get`, `exists`, and `delete`. It incorporates retry logic and error handling for robust operation. (`api-server/app/singletons/redis_manager.py`, [api-server/app/singletons/redis_manager.pyR1-R169](diffhunk://#diff-7eb2196b062c5ad28ee93042fbde8931c9aac05a1350231636d05b05e2fe7e39R1-R169))
* Introduced `RedisOperation` enumeration to standardize Redis operation names. (`api-server/app/singletons/RedisOperation.py`, [api-server/app/singletons/RedisOperation.pyR1-R9](diffhunk://#diff-008c1a6fa0b85c47ccb9754c9c832c5ad9643be53cc2d92ee9045dc01f42da61R1-R9))

### Testing
* Added unit tests for `RedisManager` to validate its behavior in isolation using mocks. (`api-server/tests/unit/auth/singletons/test_redis_manager.py`, [api-server/tests/unit/auth/singletons/test_redis_manager.pyR1-R238](diffhunk://#diff-8d0d2477073581f77275dca36289e192e3b042a2706a17f60c0b038ee9f5e6f4R1-R238))
* Added integration tests for `RedisManager` to verify real-world functionality against a live Redis instance. (`api-server/tests/integration/auth/singletons/test_redis_manager_integration.py`, [api-server/tests/integration/auth/singletons/test_redis_manager_integration.pyR1-R183](diffhunk://#diff-cfc49e8d54adef5c4a652bd768733fee389b2eb4af13a99aeccab742477af6f2R1-R183))
* Configured `pytest.ini` for test discovery and added markers for unit and integration tests. (`api-server/pytest.ini`, [api-server/pytest.iniR1-R8](diffhunk://#diff-e1f4a610d301b19f5957daf9cdc6d7856b696dae6900332f2b12305f58f233ffR1-R8))

### Dependency and Configuration Updates
* Updated `pyproject.toml` to include the `redis[hiredis]` package as a dependency. (`api-server/pyproject.toml`, [api-server/pyproject.tomlR18](diffhunk://#diff-16d9bcb0b98334686ca52a4744957a8d55f0b93b158aed4a8e746cc723171418R18))
* Updated `k8s/redis-values.yaml` to configure Redis memory limits and eviction policy for Kubernetes deployments. (`k8s/redis-values.yaml`, [k8s/redis-values.yamlR16-R19](diffhunk://#diff-35193404f0612f234086f7d4de74c36af64cd44199e9c433d1d8bab9c4893901R16-R19))

### Miscellaneous
* Updated `.gitignore` to include additional IDE-related files. (`api-server/.gitignore`, [api-server/.gitignoreL31-R37](diffhunk://#diff-803bd2ad8d918c5e9dab18802ae21b307afe2599c23a15e72cb1d6424360c77eL31-R37))