### PR TITLE
Add UnitesStrategyEnum and integrate into NodeTemplate validation

### DIFF
--- a/state-manager/app/models/node_template_model.py
+++ b/state-manager/app/models/node_template_model.py
@@ -1,10 +1,17 @@
 from pydantic import Field, BaseModel, field_validator
 from typing import Any, Optional, List
 from .dependent_string import DependentString
+from enum import Enum
+
+
+class UnitesStrategyEnum(str, Enum):
+    ALL_SUCCESS = "ALL_SUCCESS"
+    ALL_DONE = "ALL_DONE"
 
 
 class Unites(BaseModel):
     identifier: str = Field(..., description="Identifier of the node")
+    strategy: UnitesStrategyEnum = Field(..., description="Strategy of the unites")
 
 
 class NodeTemplate(BaseModel):


### PR DESCRIPTION
- Introduced UnitesStrategyEnum to define strategies for unites: ALL_SUCCESS and ALL_DONE.
- Updated NodeTemplate to include a strategy field, enhancing the model's validation capabilities.
- Modified the check_unites_satisfied function in create_next_states.py to incorporate the new strategy logic for state satisfaction checks, improving the handling of unites conditions.