### PR TITLE
ci: restrict image publish/deploy to canonical repo and main branch

### DIFF
--- a/.github/workflows/deploy-kubernetes.yml
+++ b/.github/workflows/deploy-kubernetes.yml
@@ -6,6 +6,7 @@ on:
 jobs:  
   deploy-api-server:
     runs-on: ubuntu-latest
+    if: github.repository == 'exospherehost/exospherehost'
     environment:
       name: deploy-kubernetes
     steps:

--- a/.github/workflows/publish-api-server.yml
+++ b/.github/workflows/publish-api-server.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
+    if: github.repository == 'exospherehost/exospherehost'
 
     permissions:
       contents: read
@@ -58,6 +59,7 @@ jobs:
   deploy-to-k8s:
     needs: publish-image
     runs-on: ubuntu-latest
+    if: github.repository == 'exospherehost/exospherehost'
 
     steps:
       - name: Deploy to K8s

--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
+    if: github.repository == 'exospherehost/exospherehost'
 
     permissions:
       contents: read

--- a/.github/workflows/publish-landing-page.yml
+++ b/.github/workflows/publish-landing-page.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
+    if: github.repository == 'exospherehost/exospherehost'
 
     permissions:
       contents: read
@@ -59,6 +60,7 @@ jobs:
   deploy-to-k8s:
     needs: publish-image
     runs-on: ubuntu-latest
+    if: github.repository == 'exospherehost/exospherehost'
     steps:
       - name: Deploy to K8s
         run: |

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -66,6 +66,7 @@ jobs:
     defaults:
       run:
         working-directory: python-sdk
+    if: github.repository == 'exospherehost/exospherehost'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-state-mangaer.yml
+++ b/.github/workflows/publish-state-mangaer.yml
@@ -74,6 +74,7 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     needs: test
+    if: github.repository == 'exospherehost/exospherehost'
 
     permissions:
       contents: read

--- a/.github/workflows/release-dashboard.yml
+++ b/.github/workflows/release-dashboard.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
+    if: github.repository == 'exospherehost/exospherehost'
 
     permissions:
       contents: read

--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -62,6 +62,7 @@ jobs:
     defaults:
       run:
         working-directory: python-sdk
+    if: github.repository == 'exospherehost/exospherehost'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-state-manager.yml
+++ b/.github/workflows/release-state-manager.yml
@@ -67,6 +67,7 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     needs: test
+    if: github.repository == 'exospherehost/exospherehost'
 
     permissions:
       contents: read


### PR DESCRIPTION
- Add repo guard to publish and release workflows
- Ensure deploy workflow only runs in canonical repo
- Align with #69 to prevent publishing from forks/PRs