### PR TITLE
Added 2 attributes in partialFilterExpression to optimize IndexScan

### DIFF
--- a/state-manager/app/models/db/state.py
+++ b/state-manager/app/models/db/state.py
@@ -95,7 +95,7 @@ class State(BaseDatabaseModel):
                 name="uniq_fanout_retry",
                 partialFilterExpression={
                     "fanout_id": { "$exists": True },
-                    "status": { "$in": ["CREATED", "QUEUED", "EXECUTED"] }
+                    "status": { "$in": [StateStatusEnum.CREATED, StateStatusEnum.QUEUED, StateStatusEnum.EXECUTED] }
                 }
             )
         ]

--- a/state-manager/app/models/db/state.py
+++ b/state-manager/app/models/db/state.py
@@ -9,7 +9,7 @@ import hashlib
 import json
 import time
 import uuid
-
+    
 class State(BaseDatabaseModel):
     node_name: str = Field(..., description="Name of the node of the state")
     namespace_name: str = Field(..., description="Name of the namespace of the state")
@@ -92,13 +92,10 @@ class State(BaseDatabaseModel):
                     ("fanout_id", 1),
                 ],
                 unique=True,
-                name="uniq_fanout_retry"
-            ),
-            IndexModel(
-                [
-                    ("run_id", 1),
-                    ("status", 1),
-                ],
-                name="run_id_status_index"
+                name="uniq_fanout_retry",
+                partialFilterExpression={
+                    "fanout_id": { "$exists": True },
+                    "status": { "$in": ["CREATED", "QUEUED", "EXECUTED"] }
+                }
             )
         ]


### PR DESCRIPTION
Index now applies only to documents where:
- fanout_id exists
- status is in {CREATED, QUEUED, EXECUTED}