### PR TITLE
feat: add auto-refresh frequency dropdown to dashboard

### DIFF
--- a/dashboard/src/components/RunsTable.tsx
+++ b/dashboard/src/components/RunsTable.tsx
@@ -23,6 +23,14 @@ interface RunsTableProps {
   namespace: string;
 }
 
+const REFRESH_OPTIONS = [
+  { label: "Off", value: 0 },
+  { label: "5 seconds", value: 5000 },
+  { label: "10 seconds", value: 10000 },
+  { label: "30 seconds", value: 30000 },
+  { label: "1 minute", value: 60000 },
+];
+
 export const RunsTable: React.FC<RunsTableProps> = ({
   namespace
 }) => {
@@ -33,6 +41,7 @@ export const RunsTable: React.FC<RunsTableProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [showGraph, setShowGraph] = useState(false);
+  const [refreshInterval, setRefreshInterval] = useState(0);
 
   const loadRuns = useCallback(async (page: number, size: number) => {
     setIsLoading(true);
@@ -53,6 +62,16 @@ export const RunsTable: React.FC<RunsTableProps> = ({
       loadRuns(currentPage, pageSize);
     }
   }, [namespace, currentPage, pageSize, loadRuns]);
+
+  useEffect(() => {
+    if (refreshInterval === 0) return;
+
+    const interval = setInterval(() => {
+      loadRuns(currentPage, pageSize);
+    }, refreshInterval);
+
+    return () => clearInterval(interval);
+  }, [refreshInterval, currentPage, pageSize, loadRuns]);
 
   const handlePageChange = (newPage: number) => {
     setCurrentPage(newPage);
@@ -144,6 +163,22 @@ export const RunsTable: React.FC<RunsTableProps> = ({
             <p className="text-sm text-gray-600">Monitor and visualize workflow executions</p>
           </div>
         </div>
+
+        <div className="flex items-center space-x-2">
+          <label className="text-sm text-gray-700">Auto-refresh:</label>
+          <select
+            value={refreshInterval}
+            onChange={(e) => setRefreshInterval(Number(e.target.value))}
+            className="border border-gray-300 rounded-md px-2 py-1 text-sm"
+          >
+            {REFRESH_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
         <button
           onClick={() => loadRuns(currentPage, pageSize)}
           className="flex items-center space-x-2 px-4 py-2 bg-[#031035] text-white rounded-lg hover:bg-[#0a1a4a] transition-colors"

--- a/dashboard/src/components/RunsTable.tsx
+++ b/dashboard/src/components/RunsTable.tsx
@@ -181,29 +181,37 @@ export const RunsTable: React.FC<RunsTableProps> = ({
         </div>
 
         <div className="flex items-center space-x-2">
-          <label htmlFor='auto-refresh-select' className="text-sm text-gray-700">Auto-refresh:</label>
+          <label 
+          htmlFor="auto-refresh-select" 
+          className="text-xs font-medium text-gray-600"
+          >
+            Auto-refresh
+          </label>
           <select
-            id='auto-refresh-select'
+            id="auto-refresh-select"
             value={refreshInterval}
             onChange={(e) => setRefreshInterval(Number(e.target.value) as RefreshMs)}
-            className="border border-gray-300 rounded-md px-2 py-1 text-sm"
-          >
-            {REFRESH_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
+            className="px-3 py-2 text-sm border border-gray-300 rounded-lg bg-white shadow-sm 
+               focus:outline-none focus:ring-2 focus:ring-[#031035] focus:border-[#031035] 
+               hover:border-gray-400 transition"
+            >
+              {REFRESH_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
           </select>
-        </div>
 
-        <button
-          onClick={() => loadRuns(currentPage, pageSize)}
-          className="flex items-center space-x-2 px-4 py-2 bg-[#031035] text-white rounded-lg hover:bg-[#0a1a4a] transition-colors"
-        >
-          <RefreshCw className="w-4 h-4" />
-          <span>Refresh</span>
-        </button>
+          <button
+            onClick={() => loadRuns(currentPage, pageSize)}
+            className="flex items-center space-x-2 px-4 py-2 bg-[#031035] text-white rounded-lg hover:bg-[#0a1a4a] transition-colors shadow-sm"
+          >
+            <RefreshCw className="w-4 h-4" />
+            <span>Refresh</span>
+          </button>
+        </div>
       </div>
+
 
       {/* Graph Visualization */}
       {showGraph && selectedRunId && (

--- a/dashboard/src/components/RunsTable.tsx
+++ b/dashboard/src/components/RunsTable.tsx
@@ -31,6 +31,8 @@ const REFRESH_OPTIONS = [
   { label: "1 minute", value: 60000 },
 ] as const;
 
+type RefreshMs = typeof REFRESH_OPTIONS[number]['value'];
+
 export const RunsTable: React.FC<RunsTableProps> = ({
   namespace
 }) => {
@@ -41,7 +43,7 @@ export const RunsTable: React.FC<RunsTableProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [showGraph, setShowGraph] = useState(false);
-  const [refreshInterval, setRefreshInterval] = useState(0);
+  const [refreshInterval, setRefreshInterval] = useState<RefreshMs>(0);
 
   const loadRuns = useCallback(async (page: number, size: number) => {
     setIsLoading(true);
@@ -183,7 +185,7 @@ export const RunsTable: React.FC<RunsTableProps> = ({
           <select
             id='auto-refresh-select'
             value={refreshInterval}
-            onChange={(e) => setRefreshInterval(Number(e.target.value))}
+            onChange={(e) => setRefreshInterval(Number(e.target.value) as RefreshMs)}
             className="border border-gray-300 rounded-md px-2 py-1 text-sm"
           >
             {REFRESH_OPTIONS.map((option) => (


### PR DESCRIPTION
## Description
Added a dropdown that allows users to select polling frequency for real-time updates of graph execution progress.

## Changes Made
- Added state `refreshInterval` 
- Added dropdown with options: Off, 5 seconds, 10 seconds, 30 seconds, 1 minute
- Added useEffect to use dynamic interval for polling

## Testing
- [x] Dropdown correctly changes refresh frequency
- [x] "Off" option disables auto-refresh
- [x] All existing functionality works as before
- [x] No console errors

Closes #371