### PR TITLE
Enhance manual retry state functionality by adding 'manul_retry_fanout_id'

### DIFF
--- a/state-manager/app/controller/manual_retry_state.py
+++ b/state-manager/app/controller/manual_retry_state.py
@@ -30,7 +30,8 @@ async def manual_retry_state(namespace_name: str, state_id: PydanticObjectId, bo
                 error=None,
                 parents=state.parents,
                 does_unites=state.does_unites,
-                fanout_id=body.fanout_id # this will ensure that multiple unwanted retries are not formed because of index in database
+                fanout_id=body.fanout_id, # this will ensure that multiple unwanted retries are not formed because of index in database
+                manul_retry_fanout_id=body.fanout_id
             )
             retry_state = await retry_state.insert()
             logger.info(f"Retry state {retry_state.id} created for state {state_id}", x_exosphere_request_id=x_exosphere_request_id)

--- a/state-manager/app/models/db/state.py
+++ b/state-manager/app/models/db/state.py
@@ -27,6 +27,7 @@ class State(BaseDatabaseModel):
     enqueue_after: int = Field(default_factory=lambda: int(time.time() * 1000), gt=0, description="Unix time in milliseconds after which the state should be enqueued")
     retry_count: int = Field(default=0, description="Number of times the state has been retried")
     fanout_id: str = Field(default_factory=lambda: str(uuid.uuid4()), description="Fanout ID of the state")
+    manul_retry_fanout_id: str = Field(default="", description="Fanout ID of the state that is manually retried")
 
     @before_event([Insert, Replace, Save])
     def _generate_fingerprint(self):
@@ -42,6 +43,7 @@ class State(BaseDatabaseModel):
             "run_id": self.run_id,
             "retry_count": self.retry_count,
             "parents": {k: str(v) for k, v in self.parents.items()},
+            "manul_retry_fanout_id": self.manul_retry_fanout_id,
         }
         payload = json.dumps(
             data,


### PR DESCRIPTION
Field and updating related logic. This change ensures better tracking of manually retried states and improves the overall state management process.

Majorly this fixes bugs with unites. 