### PR TITLE
Optimize GitHub Actions workflows for State Manager & Dashboard builds

### DIFF
--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -1,4 +1,4 @@
-name: Publish Dashboard image to GHCR
+name: Publish Dashboard image to GHCR & DockerHub
 
 on:
   push:
@@ -10,22 +10,19 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/exosphere-dashboard
+  GHCR_REGISTRY: ghcr.io
+  DOCKER_REGISTRY: docker.io
+  IMAGE_NAME: exosphere-dashboard
   SHA_TAG: ${{ github.sha }}
 
 jobs:
-  publish-image-on-ghcr:
+  publish-image:
     runs-on: ubuntu-latest
     if: github.repository == 'exospherehost/exospherehost'
 
     permissions:
       contents: read
       packages: write
-
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      json: ${{ steps.meta.outputs.json }}
 
     steps:
       - uses: actions/checkout@v4
@@ -40,51 +37,10 @@ jobs:
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate tags & labels
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=beta-latest
-            type=sha,format=short
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: ./dashboard
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: true
-          sbom: true
-
-  publish-image-on-docker:
-    runs-on: ubuntu-latest
-    if: github.repository == 'exospherehost/exospherehost'
-
-    permissions:
-      contents: read
-      packages: write
-
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      json: ${{ steps.meta.outputs.json }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      - uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -96,7 +52,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+            ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=beta-latest
             type=sha,format=short

--- a/.github/workflows/publish-state-mangaer.yml
+++ b/.github/workflows/publish-state-mangaer.yml
@@ -1,4 +1,4 @@
-name: Publish State Manager image to GHCR 
+name: Publish State Manager image to GHCR & DockerHub
 
 on:
   push:
@@ -8,8 +8,9 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/exosphere-state-manager
+  GHCR_REGISTRY: ghcr.io
+  DOCKER_REGISTRY: docker.io
+  IMAGE_NAME: exosphere-state-manager
   SHA_TAG: ${{ github.sha }}
 
 jobs:
@@ -46,8 +47,7 @@ jobs:
 
       - name: Install dev dependencies with uv
         working-directory: state-manager
-        run: |
-          uv sync --group dev
+        run: uv sync --group dev
 
       - name: Run full test suite with coverage
         working-directory: state-manager
@@ -69,7 +69,7 @@ jobs:
           name: state-manager-coverage-report
           fail_ci_if_error: true
 
-  publish-image-on-ghcr:
+  publish-image:
     runs-on: ubuntu-latest
     needs: test
     if: github.repository == 'exospherehost/exospherehost'
@@ -77,10 +77,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      json: ${{ steps.meta.outputs.json }}
 
     steps:
       - uses: actions/checkout@v4
@@ -95,52 +91,9 @@ jobs:
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate tags & labels
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw, value=beta-latest
-            type=sha, value=${{ env.SHA_TAG }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: ./state-manager
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: true
-          sbom: true
-
-  publish-image-on-docker-hub:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.repository == 'exospherehost/exospherehost'
-
-    permissions:
-      contents: read
-      packages: write
-
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      json: ${{ steps.meta.outputs.json }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      - uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -152,10 +105,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+            ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw, value=beta-latest
-            type=sha, value=${{ env.SHA_TAG }}
+            type=raw,value=beta-latest
+            type=sha,format=short
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/release-dashboard.yml
+++ b/.github/workflows/release-dashboard.yml
@@ -5,8 +5,9 @@ on:
     types: [published]
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/exosphere-dashboard
+  GHCR_REGISTRY: ghcr.io
+  DOCKER_REGISTRY: docker.io
+  IMAGE_NAME: exosphere-dashboard
   SHA_TAG: ${{ github.sha }}
 
 jobs:
@@ -17,10 +18,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      json: ${{ steps.meta.outputs.json }}
 
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +46,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+            ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
             type=semver,pattern={{version}}

--- a/.github/workflows/release-dashboard.yml
+++ b/.github/workflows/release-dashboard.yml
@@ -10,7 +10,7 @@ env:
   SHA_TAG: ${{ github.sha }}
 
 jobs:
-  publish-image-on-ghcr:
+  publish-image:
     runs-on: ubuntu-latest
     if: github.repository == 'exospherehost/exospherehost'
 
@@ -38,51 +38,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate tags & labels
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,format=short
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: ./dashboard
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: true
-          sbom: true
-
-  publish-image-on-docker-hub:
-    runs-on: ubuntu-latest
-    if: github.repository == 'exospherehost/exospherehost'
-
-    permissions:
-      contents: read
-      packages: write
-
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      json: ${{ steps.meta.outputs.json }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      - uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/release-state-manager.yml
+++ b/.github/workflows/release-state-manager.yml
@@ -119,4 +119,6 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
-          labels
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true

--- a/.github/workflows/release-state-manager.yml
+++ b/.github/workflows/release-state-manager.yml
@@ -5,8 +5,9 @@ on:
     types: [published]
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/exosphere-state-manager
+  GHCR_REGISTRY: ghcr.io
+  DOCKER_REGISTRY: docker.io
+  IMAGE_NAME: exosphere-state-manager
   SHA_TAG: ${{ github.sha }}
 
 jobs:
@@ -43,8 +44,7 @@ jobs:
 
       - name: Install dev dependencies with uv
         working-directory: state-manager
-        run: |
-          uv sync --group dev
+        run: uv sync --group dev
           
       - name: Run full test suite with coverage
         working-directory: state-manager
@@ -66,7 +66,7 @@ jobs:
           name: state-manager-coverage-report
           fail_ci_if_error: true
 
-  publish-image-on-ghcr:
+  publish-image:
     runs-on: ubuntu-latest
     needs: test
     if: github.repository == 'exospherehost/exospherehost'
@@ -74,10 +74,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      json: ${{ steps.meta.outputs.json }}
 
     steps:
       - uses: actions/checkout@v4
@@ -92,55 +88,9 @@ jobs:
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate tags & labels
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,format=short
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: ./state-manager
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: true
-          sbom: true
-
-  publish-image-on-docker:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.repository == 'exospherehost/exospherehost'
-
-    permissions:
-      contents: read
-      packages: write
-    
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      json: ${{ steps.meta.outputs.json }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      - uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -152,7 +102,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+            ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
             type=semver,pattern={{version}}
@@ -167,6 +119,4 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: true
-          sbom: true
+          labels


### PR DESCRIPTION
## What Changed
- Consolidated duplicate build jobs (`publish-image-on-ghcr` & `publish-image-on-docker`) into a single job per workflow.  
- Ensured one build per workflow, pushing the same image to both **GHCR** and **DockerHub**.    
 
